### PR TITLE
Add toggable CRT effect to ContentView

### DIFF
--- a/AppSettings.swift
+++ b/AppSettings.swift
@@ -52,6 +52,8 @@ class AppSettings: ObservableObject {
         }
     }
     
+    @Published var crtEffectEnabled: Bool = false // P9707
+    
     /// Todas as cores disponíveis (sistema + personalizadas)
     var availableColors: [(name: String, color: Color)] {
         let system = Self.systemColors
@@ -243,5 +245,9 @@ class AppSettings: ObservableObject {
         
         // Atualiza apenas os status da categoria modificada
         customStatus = customStatus.filter { $0.category != category } + updatedStatus
+    }
+    
+    func toggleCRTEffect() { // P4b5e
+        crtEffectEnabled.toggle()
     }
 }

--- a/CRTEffect.swift
+++ b/CRTEffect.swift
@@ -1,0 +1,99 @@
+import SwiftUI
+
+struct CRTEffectModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .overlay(GrainView().blendMode(.overlay))
+            .overlay(ScanLinesView().blendMode(.multiply))
+            .overlay(ChromaticAberrationView())
+            .overlay(BleedView())
+    }
+}
+
+struct GrainView: View {
+    @State private var timer = Timer.publish(every: 0.05, on: .main, in: .common).autoconnect()
+    @State private var grainOffset: CGFloat = 0
+    
+    var body: some View {
+        GeometryReader { geometry in
+            Rectangle()
+                .fill(
+                    LinearGradient(
+                        gradient: Gradient(colors: [.black, .white]),
+                        startPoint: .top,
+                        endPoint: .bottom
+                    )
+                )
+                .mask(
+                    Image("grain")
+                        .resizable()
+                        .scaledToFill()
+                        .offset(x: grainOffset, y: grainOffset)
+                )
+                .onReceive(timer) { _ in
+                    grainOffset = CGFloat.random(in: -10...10)
+                }
+        }
+    }
+}
+
+struct ScanLinesView: View {
+    @State private var timer = Timer.publish(every: 0.1, on: .main, in: .common).autoconnect()
+    @State private var scanLineOffset: CGFloat = 0
+    
+    var body: some View {
+        GeometryReader { geometry in
+            Rectangle()
+                .fill(
+                    LinearGradient(
+                        gradient: Gradient(colors: [.black, .white]),
+                        startPoint: .top,
+                        endPoint: .bottom
+                    )
+                )
+                .mask(
+                    Image("scanlines")
+                        .resizable()
+                        .scaledToFill()
+                        .offset(y: scanLineOffset)
+                )
+                .onReceive(timer) { _ in
+                    scanLineOffset = CGFloat.random(in: -5...5)
+                }
+        }
+    }
+}
+
+struct ChromaticAberrationView: View {
+    var body: some View {
+        GeometryReader { geometry in
+            ZStack {
+                Color.red
+                    .blendMode(.screen)
+                    .offset(x: -1, y: -1)
+                Color.green
+                    .blendMode(.screen)
+                    .offset(x: 1, y: 1)
+                Color.blue
+                    .blendMode(.screen)
+                    .offset(x: 1, y: -1)
+            }
+        }
+    }
+}
+
+struct BleedView: View {
+    var body: some View {
+        GeometryReader { geometry in
+            Rectangle()
+                .fill(
+                    RadialGradient(
+                        gradient: Gradient(colors: [.white.opacity(0.1), .clear]),
+                        center: .center,
+                        startRadius: 0,
+                        endRadius: geometry.size.width / 2
+                    )
+                )
+        }
+    }
+}

--- a/CommandManager.swift
+++ b/CommandManager.swift
@@ -6,6 +6,7 @@ class CommandManager: ObservableObject {
     enum Command: String, CaseIterable {
         case color = "/color"
         case status = "/status"
+        case crt = "/toggle-crt" // P4ab0
         
         var description: String {
             switch self {
@@ -13,6 +14,8 @@ class CommandManager: ObservableObject {
                 return "Configure app colors"
             case .status:
                 return "Manage status syles and create new status"
+            case .crt:
+                return "Toggle CRT effect" // P07bb
             }
         }
     }
@@ -57,6 +60,8 @@ class CommandManager: ObservableObject {
             showingColorSettings = true
         case .status:
             showingStatusSettings = true
+        case .crt:
+            AppSettings.shared.toggleCRTEffect() // Pc42c
         }
     }
 }

--- a/ContentView.swift
+++ b/ContentView.swift
@@ -1,15 +1,11 @@
-//
-//  ContentView.swift
-//  projects
-//
-//  Created by Raul de Avila Junior on 06/01/25.
-//
-
 import SwiftUI
 
 struct ContentView: View {
+    @EnvironmentObject var settings: AppSettings
+    
     var body: some View {
         TaskListView()
+            .modifier(CRTEffectModifier().opacity(settings.crtEffectEnabled ? 1 : 0))
     }
 }
 


### PR DESCRIPTION
Add a toggable CRT effect to `ContentView` and implement the necessary changes to support it.

* **AppSettings.swift**
  - Add `@Published var crtEffectEnabled: Bool` property to manage the CRT effect state.
  - Add `toggleCRTEffect()` method to toggle the CRT effect state.

* **CommandManager.swift**
  - Add a new command case `.crt` with raw value `/toggle-crt` to the `Command` enum.
  - Update the `description` property of the `Command` enum to include the CRT effect toggle description.
  - Update the `executeCommand` method to handle the new `.crt` command by toggling the CRT effect in `AppSettings`.

* **ContentView.swift**
  - Add a CRT effect view modifier to apply the CRT effect to the `TaskListView`.
  - Conditionally apply the CRT effect based on the `crtEffectEnabled` property from `AppSettings`.

* **CRTEffect.swift**
  - Define a new Swift file to implement the CRT effect view modifier.
  - Implement the CRT effect with grain, bleed, chromatic aberration, and movable scan lines.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/rauldeavila/projects/pull/1?shareId=0ebe6d2d-756b-48ac-90db-8099ff4a65a0).